### PR TITLE
Fix alignment of 64-bit ints on x86 QNX 7.0

### DIFF
--- a/compiler/rustc_target/src/spec/i586_pc_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/i586_pc_nto_qnx700.rs
@@ -6,7 +6,7 @@ pub fn target() -> Target {
         llvm_target: "i586-pc-unknown".into(),
         pointer_width: 32,
         data_layout: "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-\
-            f64:32:64-f80:32-n8:16:32-S128"
+            i64:64-f64:32:64-f80:32-n8:16:32-S128"
             .into(),
         arch: "x86".into(),
         options: TargetOptions {


### PR DESCRIPTION
Preliminary PR before sending to the main repo.

In testing libc and std rust on x86 QNX Neutrino 7.0, I found that the data layout I had used previously had an error - on 32-bit x86, the nto/gcc toolchain aligns 64-bit integer types to 64 bits, which is different from Rust's assumed default of 32-bit alignment.

Separating this from the rest of my 7.0 std work because it is a bug in the already merged no_std support.